### PR TITLE
Add C/CXX flags to metis and superLU build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,6 +538,8 @@ else()
                                     -DMETIS_PATH=../parmetis/metis
                                     -DCMAKE_C_COMPILER=${MPI_C_COMPILER}
                                     -DCMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}
+                                    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                                    -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                                     -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE
                                     -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
                                     -DPARMETIS_INSTALL_PREFIX:PATH=<INSTALL_DIR>
@@ -558,6 +560,8 @@ else()
                                     -DGKLIB_PATH=../metis/metis/GKlib
                                     -DCMAKE_C_COMPILER=${MPI_C_COMPILER}
                                     -DCMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}
+                                    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                                    -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                                     -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE
                                     -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
                                     -DMETIS_INSTALL_PREFIX:PATH=<INSTALL_DIR>
@@ -592,6 +596,8 @@ else()
                                     -DXSDK_INDEX_SIZE=64
                                     -DCMAKE_C_COMPILER=${MPI_C_COMPILER}
                                     -DCMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}
+                                    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                                    -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                                     -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE
                                     -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
                                     -DSUPERLU_INSTALL_PREFIX:PATH=<INSTALL_DIR>

--- a/scripts/geosx_cori_tpl.sh
+++ b/scripts/geosx_cori_tpl.sh
@@ -1,0 +1,19 @@
+#
+#Please add the following variables to bash_profile.ext
+#
+
+export CRAYPE_LINK_TYPE=dynamic
+export HDF5_USE_FILE_LOCKING=FALSE
+export XTPE_LINK_TYPE=dynamic
+
+#Please set directory to GEOSX
+export GEOSX_DIR=/global/homes/v/vargas45/Git-Repos/TEST_GEOSX/GEOSX
+
+#Build TPLs
+python config-build.py -hc ${GEOSX_DIR}/host-configs/cori-intel.cmake -bt Release && cd build-cori-intel-release && make -j && 
+
+#Build GEOSX
+cd ${GEOSX_DIR}/src/externalComponents && git submodule deinit PAMELA && git submodule deinit PVTPackage && cd ${GEOSX_DIR} &&
+python scripts/config-build.py -hc host-configs/cori-intel.cmake -bt Release && cd build-cori-intel-release && make -j 
+
+


### PR DESCRIPTION
By passing in the OpenMP flag and std=c99 flags we remove warnings and build errors. Flags are specified from the host config. 