### PR TITLE
Solutions for superlu and hypre configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,11 +632,9 @@ ExternalProject_Add( superlu_dist
                                       -DTPL_LAPACK_LIBRARIES:STRING=${LAPACK_LIBRARIES}
                      CMAKE_ARGS -D CMAKE_BUILD_TYPE:STRING=RELEASE
                                 -D XSDK_INDEX_SIZE=64
-                                -D CMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                                -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                                -D CMAKE_C_COMPILER=${MPI_C_COMPILER}
+                                -D CMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}
                                 -D CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
-                                -D MPI_C_COMPILER=${MPI_C_COMPILER}
-                                -D MPI_CXX_COMPILER=${MPI_CXX_COMPILER}
                                 -D CMAKE_C_FLAGS=${C_FLAGS_NO_WARNINGS}
                                 -D CMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
                                 -D CMAKE_CXX_FLAGS=${CXX_FLAGS_NO_WARNINGS}
@@ -696,7 +694,7 @@ ExternalProject_Add( hypre
                      INSTALL_DIR ${HYPRE_DIR}
                      DEPENDS superlu_dist
                      BINARY_DIR ${PROJECT_BINARY_DIR}/hypre/src/hypre/src
-                     CONFIGURE_COMMAND cat ${PROJECT_BINARY_DIR}/config_for_geosx && source ${PROJECT_BINARY_DIR}/config_for_geosx
+                     CONFIGURE_COMMAND cat ${PROJECT_BINARY_DIR}/config_for_geosx && . ${PROJECT_BINARY_DIR}/config_for_geosx
                      BUILD_COMMAND make -j ${NUM_PROC} VERBOSE=1
                      INSTALL_COMMAND make install
                    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,6 +635,8 @@ ExternalProject_Add( superlu_dist
                                 -D CMAKE_C_COMPILER=${MPI_C_COMPILER}
                                 -D CMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}
                                 -D CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+                                -D MPI_C_COMPILER=${MPI_C_COMPILER}
+                                -D MPI_CXX_COMPILER=${MPI_CXX_COMPILER}
                                 -D CMAKE_C_FLAGS=${C_FLAGS_NO_WARNINGS}
                                 -D CMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
                                 -D CMAKE_CXX_FLAGS=${CXX_FLAGS_NO_WARNINGS}


### PR DESCRIPTION
To allow cmake 3.10.2 (default with Ubuntu 18.04) to compile the TPLs, I changed the main `CMakeLists.txt` in two sections:
- superlu_dist: defining `CMAKE_C_COMPILER` as `MPI_C_COMPILER` and `CMAKE_CXX_COMPILER` as `MPI_CXX_COMPILER`. No needs for `MPI_C_COMPILER` and `MPI_CXX_COMPILER`
- hypre: using `.` instead of `source`, to allow cmake to run with `sh` also (not only `bash`)