### PR TITLE
Provide MPI fortran compiler to Trilinos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -675,8 +675,8 @@ if (ENABLE_TRILINOS)
                                     -D CMAKE_CXX_COMPILER:PATH=${TRILINOS_CXX_COMPILER}
                                     -D CMAKE_CXX_FLAGS:STRING=${TRILINOS_CXX_FLAGS}
                                     -D CMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
-                                    -D CMAKE_Fortran_COMPILER:PATH=${CMAKE_Fortran_COMPILER}
-                                    -D CMAKE_Fortran_FLAGS_RELEASE:STRING=${CMAKE_Fortran_FLAGS_RELEASE}
+                                    -D CMAKE_Fortran_COMPILER:PATH=${TRILINOS_Fortran_COMPILER}
+                                    -D CMAKE_Fortran_FLAGS_RELEASE:STRING=${TRILINOS_Fortran_COMPILER}
                                     -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
                                     -D CMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
                                     -D TPL_ENABLE_MPI:BOOL=${ENABLE_MPI}


### PR DESCRIPTION
The Fortran compiler was not the MPI one and I actually experienced 
a building error in some configuration because of this discrepancy.