### PR TITLE
Add MOAB (Mesh-Oriented datABase) as a mandatory dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -799,7 +799,7 @@ ExternalProject_Add( moab
                      PREFIX ${PROJECT_BINARY_DIR}/moab
                      INSTALL_DIR ${MOAB_DIR}
                      DEPENDS ${MOAB_DEPENDENCIES}
-                     CONFIGURE_COMMAND autoreconf -fi && CC=${MOAB_C_COMPILER} CXX=${MOAB_CXX_COMPILER} FC=${MOAB_Fortran_COMPILER} ./configure
+                     CONFIGURE_COMMAND cd ../moab && autoreconf -fi && CC=${MOAB_C_COMPILER} CXX=${MOAB_CXX_COMPILER} FC=${MOAB_Fortran_COMPILER} ./configure
                          --disable-fortran ${MOAB_WITH_MPI}
                          --with-blas --with-lapack
                          --with-hdf5=${HDF5_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,6 @@ ExternalProject_Add( hdf5
 list(APPEND HDF5_DEPENDENCIES hdf5 )
 list(APPEND build_list hdf5 )
 
-
 ################################
 # Conduit
 ################################
@@ -773,6 +772,45 @@ ExternalProject_Add( metis
 
 list(APPEND build_list metis )
 
+################################
+# MOAB (Mesh-Oriented datABase) is a mandatory dependency
+################################
+
+# MOAB is a mandatory dependency
+set( MOAB_DEPENDENCIES hdf5 metis parmetis )
+set( MOAB_DIR "${CMAKE_INSTALL_PREFIX}/moab" )
+set( MOAB_URL "${TPL_MIRROR_DIR}/moab-5.2.1.tar.gz" )
+message( STATUS "Building MOAB found at ${MOAB_URL}" )
+
+if( ${ENABLE_MPI} )
+  set( MOAB_C_COMPILER ${MPI_C_COMPILER} )
+  set( MOAB_CXX_COMPILER ${MPI_CXX_COMPILER} )
+  set( MOAB_Fortran_COMPILER ${MPI_Fortran_COMPILER} )
+  set( MOAB_WITH_MPI --with-mpi )
+else()
+  set( MOAB_C_COMPILER ${CMAKE_C_COMPILER} )
+  set( MOAB_CXX_COMPILER ${CMAKE_CXX_COMPILER} )
+  set( MOAB_Fortran_COMPILER ${CMAKE_Fortran_COMPILER} )
+  set( MOAB_WITH_MPI "" )
+endif()
+
+ExternalProject_Add( moab
+                     URL ${MOAB_URL}
+                     PREFIX ${PROJECT_BINARY_DIR}/moab
+                     INSTALL_DIR ${MOAB_DIR}
+                     DEPENDS ${MOAB_DEPENDENCIES}
+                     CONFIGURE_COMMAND autoreconf -fi && CC=${MOAB_C_COMPILER} CXX=${MOAB_CXX_COMPILER} FC=${MOAB_Fortran_COMPILER} ./configure
+                         --disable-fortran ${MOAB_WITH_MPI}
+                         --with-blas --with-lapack
+                         --with-hdf5=${HDF5_DIR}
+                         --with-metis=${METIS_DIR}
+                         --with-parmetis=${PARMETIS_DIR}
+                         --without-netcdf
+                     BUILD_COMMAND ${TPL_BUILD_COMMAND}
+                     INSTALL_COMMAND ${TPL_INSTALL_COMMAND}
+                     )
+
+list( APPEND build_list moab )
 
 ################################
 # SUPERLU --

--- a/docker/gcc-ubuntu1804/Dockerfile
+++ b/docker/gcc-ubuntu1804/Dockerfile
@@ -27,7 +27,11 @@ RUN apt-get install -y --no-install-recommends \
 # And we want to test GEOSX's python configuration script.
 # Unfortunately argparse (standard library's package used by GEOSX)
 # is not in the python-minimal package so we install the whole std lib.
-    python
+    python \
+# MOAB uses those tools to convert configure.ac into the configure script
+    autoconf \
+    autotools-dev \
+    libtool
 
 # Installing more recent cmake version (3.10.2 in ubuntu is not enough)
 ARG CMAKE_VERSION=3.14.5

--- a/tplMirror/moab-5.2.1.tar.gz
+++ b/tplMirror/moab-5.2.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39760e621b7cb2db50c669ee6032248dd7c66c6d70fd0d2a1c71e75cf2762c22
+size 14632435


### PR DESCRIPTION
To be noted: 

- It passes the tests.
- Untested without `mpi`.
- I believe it builds `static` by default. Do we need the `shared` object libraries?
- No `scotch`/`ptscotch`/`zoltan` mesh partitionning.
- The `vtk` feature requires `X11`.
- It builds with `netcdf`.

First shot on smooth `gcc`/`openmpi` on `debian`, no `CUDA`.