### PR TITLE
Update Brew hash to top of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ geosx_osx_build: &geosx_osx_build
   # the https://github.com/Homebrew/homebrew-core repository).
   # To find the version, a convenient way is to browse
   # the `Formula/open-mpi.rb` history.)
-  - BREW_HASH=b899e2f34463d0c8558f71bbca796dc089ee430d
+  - BREW_HASH=b2d072dc1ff32d5c723d83d59145192e8f04fb0b
   - BREW_URL=https://raw.github.com/Homebrew/homebrew-core/${BREW_HASH}
   - brew update > /dev/null 2>&1
   - wget ${BREW_URL}/Formula/open-mpi.rb


### PR DESCRIPTION
This fixes Travis OSX builds that have been broken as of recently. In particular, it updates `open-mpi` to 4.1.0.
GEOSX is updated to new TPL tag via https://github.com/GEOSX/GEOSX/pull/1363