### PR TITLE
Adding a Pecan CPU target alongside the GPU one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ geosx_linux_build: &geosx_linux_build
 
 jobs:
   include:
-  - name: Pangea2 build
+  - name: Pangea2
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
@@ -75,38 +75,47 @@ jobs:
     - INSTALL_DIR=/workrd/SCR/GEOSX/install/gcc8/GEOSX_TPL-${TRAVIS_COMMIT:0:7}
     before_script:
     - echo "**/*.rpm" >> .dockerignore
-  - name: Pecan GPU build
+  - name: Pecan GPU
     <<: *geosx_linux_build
     env:
-    - DOCKER_REPOSITORY=geosx/pecan-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
+    - DOCKER_REPOSITORY=geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2
     - DOCKERFILE=docker/TotalEnergies/Dockerfile
     - DOCKER_ROOT_IMAGE=totogaz/pecan-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2-no-geosx:0.0.1
-    - HOST_CONFIG=docker/TotalEnergies/pecan.cmake
-    - INSTALL_DIR=/data/gpfs/Users/j0436735/travis-deploy/GEOSX_TPL-${TRAVIS_COMMIT:0:7}
+    - HOST_CONFIG=docker/TotalEnergies/pecan-GPU.cmake
+    - INSTALL_DIR=/data/gpfs/Users/j0436735/travis-deployments/GPU/GEOSX_TPL-${TRAVIS_COMMIT:0:7}
+    before_script:
+    - echo "**/*.rpm" >> .dockerignore
+  - name: Pecan CPU
+    <<: *geosx_linux_build
+    env:
+    - DOCKER_REPOSITORY=geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+    - DOCKERFILE=docker/TotalEnergies/Dockerfile
+    - DOCKER_ROOT_IMAGE=totogaz/pecan-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda10.2.89p2-no-geosx:0.0.1
+    - HOST_CONFIG=docker/TotalEnergies/pecan-CPU.cmake
+    - INSTALL_DIR=/data/gpfs/Users/j0436735/travis-deployments/CPU/GEOSX_TPL-${TRAVIS_COMMIT:0:7}
     before_script:
     - echo "**/*.rpm" >> .dockerignore
   - name: Mac OSX
     <<: *geosx_osx_build
-  - name: clang-9 build on centos
+  - name: clang-9 on centos
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
     - DOCKERFILE=docker/clang-centos/Dockerfile
-  - name: gcc-8 build on ubuntu
+  - name: gcc-8 on ubuntu
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-gcc8
     - DOCKERFILE=docker/gcc-ubuntu1804/Dockerfile
     before_script:
     - echo "**/*.rpm" >> .dockerignore
-  - name: clang-8 and cuda-10.1.243 build on ubuntu
+  - name: clang-8 and cuda-10.1.243 on ubuntu
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
     - DOCKERFILE=docker/clang-cuda/Dockerfile
-  - name: gcc-8.3.1 and cuda-10.1.243 build on centos
+  - name: gcc-8.3.1 and cuda-10.1.243 on centos
     <<: *geosx_linux_build
     env:
     - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
     - DOCKERFILE=docker/gcc-cuda/Dockerfile
-

--- a/docker/TotalEnergies/pecan-CPU.cmake
+++ b/docker/TotalEnergies/pecan-CPU.cmake
@@ -17,28 +17,6 @@ set(MPIEXEC_EXECUTABLE "${MPI_HOME}/bin/mpirun" CACHE PATH "" FORCE)
 #set(MPIEXEC_NUMPROC_FLAG   "-p pecan -n" CACHE STRING "")
 set(ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC ON CACHE BOOL "")
 
-set(ENABLE_CUDA ON CACHE PATH "" FORCE)
-set(CUDA_TOOLKIT_ROOT_DIR /hrtc/apps/cuda/10.2.89/x86_64 CACHE PATH "")
-set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "")
-set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc CACHE STRING "")
-
-set(CUDA_ARCH sm_75 CACHE STRING "")
-set(CMAKE_CUDA_STANDARD 14 CACHE STRING "")
-### The inclusion of -std=c++14 is a workaround for a cuda10/gcc8 bug ###
-set(CMAKE_CUDA_FLAGS "-restrict -arch ${CUDA_ARCH} --expt-relaxed-constexpr --expt-extended-lambda -Werror cross-execution-space-call,reorder,deprecated-declarations -Xcompiler -std=c++14" CACHE STRING "")
-set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler -DNDEBUG -Xcompiler -O3" CACHE STRING "")
-set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" CACHE STRING "")
-set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
-
-# Current version of hypre does not build with GPU support inside of docker.
-# Hypre's build system awaits to be embedded into a CUDA environment.
-# This is a bit tedious to reproduce in docker environment.
-# And since most recent version of hypre do build without this constraint.
-# Let's wait for an upgrade on our side.
-# In the mean time, if you need the GPU support for hypre,
-# simply install the classical way, with some `module load cuda`.
-#set(ENABLE_HYPRE_CUDA ON CACHE BOOL "" FORCE)
-
 set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "" FORCE)
 set(ENABLE_CALIPER ON CACHE BOOL "")
 

--- a/docker/TotalEnergies/pecan-GPU.cmake
+++ b/docker/TotalEnergies/pecan-GPU.cmake
@@ -1,0 +1,25 @@
+# Retrieve the compilers, standard libraries...
+include(${CMAKE_CURRENT_LIST_DIR}/pecan-CPU.cmake)
+# ... and just add what's dedicated to GPU.
+
+set(ENABLE_CUDA ON CACHE PATH "" FORCE)
+set(CUDA_TOOLKIT_ROOT_DIR /hrtc/apps/cuda/10.2.89/x86_64 CACHE PATH "")
+set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "")
+set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc CACHE STRING "")
+
+set(CUDA_ARCH sm_75 CACHE STRING "")
+set(CMAKE_CUDA_STANDARD 14 CACHE STRING "")
+### The inclusion of -std=c++14 is a workaround for a cuda10/gcc8 bug ###
+set(CMAKE_CUDA_FLAGS "-restrict -arch ${CUDA_ARCH} --expt-relaxed-constexpr --expt-extended-lambda -Werror cross-execution-space-call,reorder,deprecated-declarations -Xcompiler -std=c++14" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler -DNDEBUG -Xcompiler -O3" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" CACHE STRING "")
+set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
+
+# Current version of hypre does not build with GPU support inside of docker.
+# Hypre's build system awaits to be embedded into a CUDA environment.
+# This is a bit tedious to reproduce in docker environment.
+# And since most recent version of hypre do build without this constraint.
+# Let's wait for an upgrade on our side.
+# In the mean time, if you need the GPU support for hypre,
+# simply install the classical way, with some `module load cuda`.
+#set(ENABLE_HYPRE_CUDA ON CACHE BOOL "" FORCE)

--- a/docker/TotalEnergies/pecan-GPU.cmake
+++ b/docker/TotalEnergies/pecan-GPU.cmake
@@ -1,7 +1,7 @@
-# Retrieve the compilers, standard libraries...
+# Retrieve the compilers, standard libraries... from the CPU configuration
 include(${CMAKE_CURRENT_LIST_DIR}/pecan-CPU.cmake)
-# ... and just add what's dedicated to GPU.
 
+# Now let's add what's dedicated to GPU.
 set(ENABLE_CUDA ON CACHE PATH "" FORCE)
 set(CUDA_TOOLKIT_ROOT_DIR /hrtc/apps/cuda/10.2.89/x86_64 CACHE PATH "")
 set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "")


### PR DESCRIPTION
Some users are now developing on Pecan and not only launching computations.
They would greatly benefit from both `CPU` and `GPU` pre-compiled TPLs.