### PR TITLE
Update SuiteSparse version to 5.10.1 (latest)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,8 +757,8 @@ if( ENABLE_HYPRE )
   endif()
 
   if( ENABLE_HYPRE_CUDA )
-    set( HYPRE_CUDA_FLAGS "--with-cuda --enable-cusparse --enable-unified-memory" )
     string( SUBSTRING ${CUDA_ARCH} 3 -1 HYPRE_CUDA_SM ) # sm_XY -> XY
+    set( HYPRE_CUDA_FLAGS "--with-cuda --with-cuda-home=${CUDA_TOOLKIT_ROOT_DIR} --enable-cusparse --enable-unified-memory --with-gpu-arch=${HYPRE_CUDA_SM}" )
   endif()
 
   if( ENABLE_HYPRE_CUDA )
@@ -786,8 +786,6 @@ if( ENABLE_HYPRE )
   CXXFLAGS=\"${HYPRE_CXX_FLAGS}\" \
   FC=${HYPRE_Fortran_COMPILER} \
   FCFLAGS=\"${HYPRE_Fortran_FLAGS}\" \
-  CUDA_HOME=\"${CUDA_TOOLKIT_ROOT_DIR}\" \
-  HYPRE_CUDA_SM=\"${HYPRE_CUDA_SM}\" \
   --prefix=${HYPRE_DIR} \
   ${HYPRE_DEBUG_FLAG} \
   ${HYPRE_INT_FLAG} \
@@ -817,7 +815,7 @@ endif()
 ################################
 if(ENABLE_SUITESPARSE)
     set(SUITESPARSE_DIR "${CMAKE_INSTALL_PREFIX}/suitesparse")
-    set(SUITESPARSE_URL "${TPL_MIRROR_DIR}/SuiteSparse-5.8.1.tar.gz")
+    set(SUITESPARSE_URL "${TPL_MIRROR_DIR}/SuiteSparse-5.10.1.tar.gz")
 
     message(STATUS "Building SUITESPARSE found at ${SUITESPARSE_URL}")
 

--- a/tplMirror/SuiteSparse-5.10.1.tar.gz
+++ b/tplMirror/SuiteSparse-5.10.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acb4d1045f48a237e70294b950153e48dce5b5f9ca8190e86c2b8c54ce00a7ee
+size 59919745

--- a/tplMirror/SuiteSparse-5.8.1.tar.gz
+++ b/tplMirror/SuiteSparse-5.8.1.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52ad5d873a0fc882778d5f522381f82714286d25d299e91f8d7d45508dc469df
-size 60011231


### PR DESCRIPTION
Needed to compile TPLs with CUDA 11.

Current version we're using (5.8.1) has two issues, the combination of which breaks the TPL build:
  * it ignores `CUDA=no` flag we're passing to the build when `CUDA_PATH` is set in the environment (which is the case if the cuda module is loaded) and still tries to compile some GPU kernels
  * it forcibly tries to compile code for `compute_30` virtual architecture which is no longer supported by CUDA 11 compiler
