### PR TITLE
Testing - Use CMake 3.19.2 for Pecan and Pangea images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,38 +95,38 @@ jobs:
     - INSTALL_DIR=/data/gpfs/Users/j0436735/travis-deployments/CPU/GEOSX_TPL-${TRAVIS_PULL_REQUEST}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:7}
     before_script:
     - echo "**/*.rpm" >> .dockerignore
-  - name: Mac OSX
-    <<: *geosx_osx_build
-  - name: Centos (7.6, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
-    - DOCKERFILE=docker/clang-centos/Dockerfile
-  - name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
-    <<: *geosx_linux_build
-    env:
-    - GCC_MAJOR_VERSION=9
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc${GCC_MAJOR_VERSION}
-    - DOCKERFILE=docker/gcc-ubuntu/Dockerfile
-    before_script:
-    - DOCKER_COMPILER_BUILD_ARG="--build-arg GCC_MAJOR_VERSION=${GCC_MAJOR_VERSION}"
-    - echo "**/*.rpm" >> .dockerignore
-  - name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
-    <<: *geosx_linux_build
-    env:
-    - GCC_MAJOR_VERSION=10
-    - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc${GCC_MAJOR_VERSION}
-    - DOCKERFILE=docker/gcc-ubuntu/Dockerfile
-    before_script:
-    - DOCKER_COMPILER_BUILD_ARG="--build-arg GCC_MAJOR_VERSION=${GCC_MAJOR_VERSION}"
-    - echo "**/*.rpm" >> .dockerignore
-  - name: Ubuntu (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
-    - DOCKERFILE=docker/clang-cuda/Dockerfile
-  - name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
-    <<: *geosx_linux_build
-    env:
-    - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
-    - DOCKERFILE=docker/gcc-cuda/Dockerfile
+# - name: Mac OSX
+#   <<: *geosx_osx_build
+# - name: Centos (7.6, clang 9.0.0 + gcc 4.9.3, open-mpi 1.10.7)
+#   <<: *geosx_linux_build
+#   env:
+#   - DOCKER_REPOSITORY=geosx/centos7.7.1908-clang9.0.0
+#   - DOCKERFILE=docker/clang-centos/Dockerfile
+# - name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)
+#   <<: *geosx_linux_build
+#   env:
+#   - GCC_MAJOR_VERSION=9
+#   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc${GCC_MAJOR_VERSION}
+#   - DOCKERFILE=docker/gcc-ubuntu/Dockerfile
+#   before_script:
+#   - DOCKER_COMPILER_BUILD_ARG="--build-arg GCC_MAJOR_VERSION=${GCC_MAJOR_VERSION}"
+#   - echo "**/*.rpm" >> .dockerignore
+# - name: Ubuntu (20.04, gcc 10.3.0, open-mpi 4.0.3)
+#   <<: *geosx_linux_build
+#   env:
+#   - GCC_MAJOR_VERSION=10
+#   - DOCKER_REPOSITORY=geosx/ubuntu20.04-gcc${GCC_MAJOR_VERSION}
+#   - DOCKERFILE=docker/gcc-ubuntu/Dockerfile
+#   before_script:
+#   - DOCKER_COMPILER_BUILD_ARG="--build-arg GCC_MAJOR_VERSION=${GCC_MAJOR_VERSION}"
+#   - echo "**/*.rpm" >> .dockerignore
+# - name: Ubuntu (18.04, clang 8.0.0 + gcc 8.3.1, open-mpi 2.1.1, cuda-10.1.243)
+#   <<: *geosx_linux_build
+#   env:
+#   - DOCKER_REPOSITORY=geosx/ubuntu18.04-clang8.0.0-cuda10.1.243
+#   - DOCKERFILE=docker/clang-cuda/Dockerfile
+# - name: Centos (7.6, gcc 8.3.1, open-mpi 1.10.7, cuda 10.1.243)
+#   <<: *geosx_linux_build
+#   env:
+#   - DOCKER_REPOSITORY=geosx/centos7.6.1810-gcc8.3.1-cuda10.1.243
+#   - DOCKERFILE=docker/gcc-cuda/Dockerfile

--- a/docker/TotalEnergies/Dockerfile
+++ b/docker/TotalEnergies/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
     zlib-devel
 
 # centos:7.6 offers a 2.8 version of cmake which is too old.
-ARG CMAKE_VERSION=3.14.5
+ARG CMAKE_VERSION=3.19.2
 RUN curl -s https://cmake.org/files/v${CMAKE_VERSION%.[0-9]*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar --directory=/usr/local --strip-components=1 -xzf -
 
 FROM tpl_toolchain_intersect_geosx_toolchain AS tpl_toolchain


### PR DESCRIPTION
Builds #155 with CMake 3.19.2 for Pecan and Pangea images

Related to GEOSX/GEOSX#1731