### PR TITLE
Update VTK version and patch a duplication bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ geosx_osx_build: &geosx_osx_build
   - git lfs pull
   script:
   - GEOSX_TPL_DIR=/usr/local/GEOSX/GEOSX_TPL && sudo mkdir -p -m a=rwx ${GEOSX_TPL_DIR}/..
-  - python scripts/config-build.py -hc ${TRAVIS_BUILD_DIR}/host-configs/darwin-clang.cmake -bt Release -DNUM_PROC=$(nproc) -DGEOSXTPL_ENABLE_DOXYGEN:BOOL=OFF -ip ${GEOSX_TPL_DIR}
+  - python scripts/config-build.py -hc ${TRAVIS_BUILD_DIR}/host-configs/darwin-clang.cmake -bt Release -ip ${GEOSX_TPL_DIR} -DNUM_PROC=$(nproc) -DGEOSXTPL_ENABLE_DOXYGEN:BOOL=OFF -DENABLE_VTK:BOOL=OFF
   - cd build-darwin-clang-release
   - make
   # The deployment phase is done here because the `deploy` stage of travis does not work for PR.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -974,7 +974,7 @@ endif()
 ################################
 if( ENABLE_VTK )
     set( VTK_DIR "${CMAKE_INSTALL_PREFIX}/vtk" )
-    set( VTK_URL "${TPL_MIRROR_DIR}/VTK-9.0.3.tar.gz" )
+    set( VTK_URL "${TPL_MIRROR_DIR}/VTK-9.1.0.tar.gz" )
 
     message( STATUS "Building VTK found at ${VTK_URL}" )
 
@@ -1002,7 +1002,9 @@ endif( ENABLE_MPI )
                          PREFIX ${PROJECT_BINARY_DIR}/vtk
                          URL ${VTK_URL}
                          INSTALL_DIR ${VTK_DIR}
-                         PATCH_COMMAND patch --directory=${PROJECT_BINARY_DIR}/vtk/src/vtk/ThirdParty/diy2/vtkdiy2/include/vtkdiy2 < ${TPL_MIRROR_DIR}/VTK-9.0.3-disable_traits.patch
+                         PATCH_COMMAND patch -p0 < ${TPL_MIRROR_DIR}/VTK-9.1.0-disable_traits.patch
+                               COMMAND patch -p0 < ${TPL_MIRROR_DIR}/VTK-9.1.0-duplicate-points-fix.patch
+                               COMMAND patch -p0 < ${TPL_MIRROR_DIR}/VTK-9.1.0-cmake-fix.patch
                          BUILD_COMMAND ${TPL_BUILD_COMMAND}
                          INSTALL_COMMAND "${TPL_INSTALL_COMMAND}"
                          CMAKE_GENERATOR ${TPL_GENERATOR}

--- a/tplMirror/VTK-9.0.3.tar.gz
+++ b/tplMirror/VTK-9.0.3.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc3eb9625b2b8dbfecb6052a2ab091fc91405de4333b0ec68f3323815154ed8a
-size 34684378

--- a/tplMirror/VTK-9.1.0-cmake-fix.patch
+++ b/tplMirror/VTK-9.1.0-cmake-fix.patch
@@ -1,0 +1,29 @@
+--- CMake/patches/3.22/FindMPI.cmake	2021-11-04 12:48:20.000000000 -0700
++++ CMake/patches/3.22/FindMPI.cmake.patched	2022-03-09 23:04:48.008672246 -0800
+@@ -1213,6 +1213,8 @@
+   set_property(TARGET MPI::MPI_${LANG} PROPERTY INTERFACE_COMPILE_DEFINITIONS "${MPI_${LANG}_COMPILE_DEFINITIONS}")
+ 
+   if(MPI_${LANG}_LINK_FLAGS)
++    string(REPLACE "," "$<COMMA>" _MPI_${LANG}_LINK_FLAGS "${MPI_${LANG}_LINK_FLAGS}")
++    string(PREPEND _MPI_${LANG}_LINK_FLAGS "SHELL:")
+     if (CMAKE_VERSION VERSION_LESS "3.18") # Introduction of `$<HOST_LINK>`
+       if (CMAKE_CUDA_COMPILER)
+         message(AUTHOR_WARNING
+@@ -1230,8 +1232,7 @@
+           "https://gitlab.kitware.com/cmake/cmake/-/issues/22007)")
+       endif ()
+     else ()
+-      string(REPLACE "," "$<COMMA>" _MPI_${LANG}_LINK_FLAGS "${MPI_${LANG}_LINK_FLAGS}")
+-      string(PREPEND _MPI_${LANG}_LINK_FLAGS "$<HOST_LINK:SHELL:")
++      string(PREPEND _MPI_${LANG}_LINK_FLAGS "$<HOST_LINK:")
+       string(APPEND _MPI_${LANG}_LINK_FLAGS ">")
+     endif ()
+     set_property(TARGET MPI::MPI_${LANG} PROPERTY INTERFACE_LINK_OPTIONS "${_MPI_${LANG}_LINK_FLAGS}")
+@@ -1823,7 +1824,6 @@
+ find_package_handle_standard_args(MPI
+     REQUIRED_VARS ${_MPI_REQ_VARS}
+     VERSION_VAR ${_MPI_MIN_VERSION}
+-    REASON_FAILURE_MESSAGE "${_MPI_FAIL_REASON}"
+     HANDLE_COMPONENTS)
+ 
+ #=============================================================================

--- a/tplMirror/VTK-9.1.0-disable_traits.patch
+++ b/tplMirror/VTK-9.1.0-disable_traits.patch
@@ -1,5 +1,5 @@
---- serialization.hpp	2022-01-28 20:11:13.058442761 +0000
-+++ serialization_patched.hpp	2022-01-28 20:11:54.151074423 +0000
+--- ThirdParty/diy2/vtkdiy2/include/vtkdiy2/serialization.hpp	2022-01-28 20:11:13.058442761 +0000
++++ ThirdParty/diy2/vtkdiy2/include/vtkdiy2/serialization_patched.hpp	2022-01-28 20:11:54.151074423 +0000
 @@ -92,11 +92,6 @@
    template<class T>
    struct Serialization: public detail::Default

--- a/tplMirror/VTK-9.1.0-duplicate-points-fix.patch
+++ b/tplMirror/VTK-9.1.0-duplicate-points-fix.patch
@@ -1,0 +1,10 @@
+--- Filters/ParallelDIY2/vtkRedistributeDataSetFilter.cxx	2022-03-08 00:35:31.589443296 -0800
++++ Filters/ParallelDIY2/vtkRedistributeDataSetFilter.cxx.patched	2022-03-08 00:36:27.214917422 -0800
+@@ -518,6 +518,7 @@
+   {
+     assert(vtkUnstructuredGrid::SafeDownCast(outputDO) != nullptr);
+     vtkNew<vtkAppendFilter> appender;
++    appender->MergePointsOn();
+ 
+     using Opts = vtk::DataObjectTreeOptions;
+     for (vtkDataObject* part : vtk::Range(result.GetPointer(),

--- a/tplMirror/VTK-9.1.0.tar.gz
+++ b/tplMirror/VTK-9.1.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96
+size 47871165


### PR DESCRIPTION
This PR updates VTK to latest and applies a patch that fixes a problem with duplicated mesh nodes resulting from merging mesh partitions assigned to the same rank (which only occurs when number of ranks is not a power of 2). There is also a fix for this in upstream VTK (not in any release version yet), but that fix caused some other issues that need more investigation. I propose that we move ahead with the patch and re-evaluate later.