### PR TITLE
Use brew's tap to install precise version of open-mpi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ geosx_osx_build: &geosx_osx_build
   # the https://github.com/Homebrew/homebrew-core repository).
   # To find the version, a convenient way is to browse
   # the `Formula/open-mpi.rb` history.)
-  - BREW_HASH=5e32fc013f872935e5574af15ee326a2f80449eb
+  - BREW_HASH=cde5d3048893a2960690bc973d47eca87d1b7b88
   - BREW_URL=https://raw.github.com/Homebrew/homebrew-core/${BREW_HASH}
   - brew update > /dev/null 2>&1
   - wget ${BREW_URL}/Formula/open-mpi.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,13 @@ language: minimal
 geosx_osx_build: &geosx_osx_build
   stage: build
   os: osx
-  osx_image: xcode12.5
+  osx_image: xcode13.2
   install:
-  # It is not immediate to get the version of open-mpi we want.
-  # (The revision is identified through its git commit hash of
-  # the https://github.com/Homebrew/homebrew-core repository).
-  # To find the version, a convenient way is to browse
-  # the `Formula/open-mpi.rb` history.)
-  - BREW_HASH=cde5d3048893a2960690bc973d47eca87d1b7b88
-  - BREW_URL=https://raw.github.com/Homebrew/homebrew-core/${BREW_HASH}
-  - brew update > /dev/null 2>&1
-  - wget ${BREW_URL}/Formula/open-mpi.rb
-  - HOMEBREW_NO_AUTO_UPDATE=1 brew install ./open-mpi.rb
-  - for dep in `brew deps open-mpi.rb`; do brew install $dep; done
-  - wget ${BREW_URL}/Formula/git-lfs.rb
-  - HOMEBREW_NO_AUTO_UPDATE=1 brew install ./git-lfs.rb
-  - for dep in `brew deps git-lfs.rb`; do brew install $dep; done
+  - BREW_OPENMPI_VERSION=4.1.1
+  - BREW_OPENMPI_TAP=$USER/local-open-mpi
+  - brew tap-new ${BREW_OPENMPI_TAP}
+  - brew extract --version=${BREW_OPENMPI_VERSION} open-mpi ${BREW_OPENMPI_TAP}
+  - brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION}
   before_script:
   - git lfs install
   - git lfs pull

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ geosx_osx_build: &geosx_osx_build
   # the https://github.com/Homebrew/homebrew-core repository).
   # To find the version, a convenient way is to browse
   # the `Formula/open-mpi.rb` history.)
-  - BREW_HASH=fd64066273528a594e1f83c9eba20556e925e51c
+  - BREW_HASH=5e32fc013f872935e5574af15ee326a2f80449eb
   - BREW_URL=https://raw.github.com/Homebrew/homebrew-core/${BREW_HASH}
   - brew update > /dev/null 2>&1
   - wget ${BREW_URL}/Formula/open-mpi.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ geosx_osx_build: &geosx_osx_build
   - BREW_OPENMPI_TAP=$USER/local-open-mpi
   - brew tap-new ${BREW_OPENMPI_TAP}
   - brew extract --version=${BREW_OPENMPI_VERSION} open-mpi ${BREW_OPENMPI_TAP}
-  - brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION}
+  - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION}
   before_script:
   - git lfs install
   - git lfs pull

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ geosx_osx_build: &geosx_osx_build
   osx_image: xcode13.2
   install:
   - BREW_OPENMPI_VERSION=4.1.1
-  - BREW_OPENMPI_TAP=$HOME/local-open-mpi
+  - BREW_OPENMPI_TAP=${USER}/local-open-mpi
   - brew tap-new ${BREW_OPENMPI_TAP}
   - brew extract --version=${BREW_OPENMPI_VERSION} open-mpi ${BREW_OPENMPI_TAP}
   - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ geosx_osx_build: &geosx_osx_build
   - BREW_OPENMPI_TAP=${USER}/local-open-mpi
   - brew tap-new ${BREW_OPENMPI_TAP}
   - brew extract --version=${BREW_OPENMPI_VERSION} open-mpi ${BREW_OPENMPI_TAP}
-  - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION}
-  - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install git-lfs
+  - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION} git-lfs
   before_script:
   - git lfs install
   - git lfs pull
@@ -24,7 +23,7 @@ geosx_osx_build: &geosx_osx_build
   - python3 -m pip install google-cloud-storage 
   - cd ${TRAVIS_BUILD_DIR}
   - openssl aes-256-cbc -K $encrypted_5ac030ea614b_key -iv $encrypted_5ac030ea614b_iv -in geosx-key.json.enc -out geosx-key.json -d
-  - python3 macosx_TPL_mngt.py ${GEOSX_TPL_DIR} geosx-key.json ${BREW_HASH}
+  - python3 macosx_TPL_mngt.py ${GEOSX_TPL_DIR} geosx-key.json ${BREW_OPENMPI_VERSION}
 
 geosx_linux_build: &geosx_linux_build
   stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ geosx_osx_build: &geosx_osx_build
   osx_image: xcode13.2
   install:
   - BREW_OPENMPI_VERSION=4.1.1
-  - BREW_OPENMPI_TAP=$USER/local-open-mpi
+  - BREW_OPENMPI_TAP=$HOME/local-open-mpi
   - brew tap-new ${BREW_OPENMPI_TAP}
   - brew extract --version=${BREW_OPENMPI_VERSION} open-mpi ${BREW_OPENMPI_TAP}
   - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install ${BREW_OPENMPI_TAP}/open-mpi@${BREW_OPENMPI_VERSION}
+  - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_MAKE_JOBS=$(nproc) brew install git-lfs
   before_script:
   - git lfs install
   - git lfs pull

--- a/macosx_TPL_mngt.py
+++ b/macosx_TPL_mngt.py
@@ -24,7 +24,7 @@ def parse_args(arguments):
     parser = argparse.ArgumentParser(description="Uploading the TPL for MACOSX so they can be reused for GEOSX.")
     parser.add_argument("tpl_dir", metavar="TPL_DIR", help="Path to the TPL folder")
     parser.add_argument("service_account_file", metavar="CONFIG_JSON", help="Path to the service accoubt json file.")
-    parser.add_argument("brew_hash", metavar="BREW_HASH", help="Current hash used for openmpi and brew.")
+    parser.add_argument("brew_openmpi_version", metavar="BREW_OPENMPI_VERSION", help="Current version of openmpi in brew.")
     return parser.parse_args(arguments)
 
 
@@ -67,7 +67,7 @@ def build_storage_client(credentials):
     return storage.Client(project=credentials.project_id, credentials=credentials)
 
 
-def upload_metadata(blob, brew_hash, tpl_dir, credentials):
+def upload_metadata(blob, brew_openmpi_version, tpl_dir, credentials):
     """
     Uploads the metadata of the blob. These metadata can be used to delete the old blobs
     (instead of relying on an implicit convention for the blob name).
@@ -75,7 +75,7 @@ def upload_metadata(blob, brew_hash, tpl_dir, credentials):
     metadata = {"metadata":{"TRAVIS_PULL_REQUEST": os.environ["TRAVIS_PULL_REQUEST"],
                             "TRAVIS_BUILD_NUMBER": os.environ["TRAVIS_BUILD_NUMBER"],
                             "TRAVIS_COMMIT": os.environ["TRAVIS_COMMIT"],
-                            "BREW_HASH": brew_hash,
+                            "BREW_OPENMPI_VERSION": brew_openmpi_version,
                             "GEOSX_TPL_DIR": tpl_dir}}
     authed_session = AuthorizedSession(credentials)
     url = "https://www.googleapis.com/storage/v1/b/%s/o/%s" % (quote(blob.bucket.name, safe=""), quote(blob.name, safe=""))
@@ -142,7 +142,7 @@ def main(arguments):
     blob_name = tpl_name_builder()
     remove_old_blobs(storage_client, old_tpl_in_pr_predicate)
     blob = upload_tpl(tpl_buff, tpl_size, blob_name, storage_client)
-    upload_metadata(blob, args.brew_hash, args.tpl_dir, credentials)
+    upload_metadata(blob, args.brew_openmpi_version, args.tpl_dir, credentials)
     logging.info('Uploaded blob "%s" to bucket "%s"' % (blob.name, blob.bucket.name))
     return 0
 


### PR DESCRIPTION
This fixes the build failure on Mac OSX.
I've been modified the way we install open-mpi using brew and its taps.
A strong difference is that from now brew recompiles open-mpi, which takes ~5 more minutes for GEOSX or TPL builds.

I also must confess that I do not know anything about brew and that I simply stack command lines there.

Related to https://github.com/GEOSX/GEOSX/pull/2008