### PR TITLE
Use ninja for GEOSX

### DIFF
--- a/docker/Stanford/Dockerfile
+++ b/docker/Stanford/Dockerfile
@@ -6,7 +6,6 @@ ARG INSTALL_DIR
 ENV GEOSX_TPL_DIR=${INSTALL_DIR}
 
 RUN yum install -y \
-    make \
     python3 \
     zlib-devel
 
@@ -17,6 +16,7 @@ RUN curl -s https://cmake.org/files/v${CMAKE_VERSION%.[0-9]*}/cmake-${CMAKE_VERS
 FROM tpl_toolchain_intersect_geosx_toolchain AS tpl_toolchain
 
 RUN yum install -y \
+    make \
     bc \
     file \
     bison \
@@ -44,3 +44,5 @@ RUN yum -y install \
     graphviz \
     libxml2 \
     git
+
+RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja

--- a/docker/TotalEnergies/Dockerfile
+++ b/docker/TotalEnergies/Dockerfile
@@ -6,7 +6,6 @@ ARG INSTALL_DIR
 ENV GEOSX_TPL_DIR=${INSTALL_DIR}
 
 RUN yum install -y \
-    make \
     python3 \
     zlib-devel
 
@@ -17,6 +16,7 @@ RUN curl -s https://cmake.org/files/v${CMAKE_VERSION%.[0-9]*}/cmake-${CMAKE_VERS
 FROM tpl_toolchain_intersect_geosx_toolchain AS tpl_toolchain
 
 RUN yum install -y \
+    make \
     bc \
     file \
     bison \
@@ -44,3 +44,5 @@ RUN yum -y install \
     graphviz \
     libxml2 \
     git
+
+RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja

--- a/docker/clang-cuda/Dockerfile
+++ b/docker/clang-cuda/Dockerfile
@@ -81,5 +81,6 @@ COPY --from=tpl_toolchain ${GEOSX_TPL_DIR} ${GEOSX_TPL_DIR}
 RUN apt-get install -y --no-install-recommends \
     openssh-client \
     texlive \
-    graphviz \
-    ninja-build
+    graphviz
+
+RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja

--- a/docker/clang-cuda/Dockerfile
+++ b/docker/clang-cuda/Dockerfile
@@ -81,5 +81,7 @@ COPY --from=tpl_toolchain ${GEOSX_TPL_DIR} ${GEOSX_TPL_DIR}
 RUN apt-get install -y --no-install-recommends \
     openssh-client \
     texlive \
-    graphviz \
-    ninja-build
+    graphviz
+
+# The ninja version provided by the current ubuntu version is too old.
+RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja

--- a/docker/clang-cuda/Dockerfile
+++ b/docker/clang-cuda/Dockerfile
@@ -20,7 +20,7 @@ RUN rm /etc/apt/sources.list.d/*.list \
 
 # Installing latest CMake version available on Lassen
 ARG CMAKE_VERSION=3.21.7
-RUN curl -s https://cmake.org/files/v${CMAKE_VERSION%.[0-9]*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar --directory=/usr/local --strip-components=1 -xzf -
+RUN curl -s https://cmake.org/files/v${CMAKE_VERSION%.[0-9]*}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz | tar --directory=/usr/local --strip-components=1 -xzf -
 
 # Installing clang
 RUN curl -fsSL http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz | tar --directory=/usr/local --strip-components=1 -xJf -

--- a/docker/clang-cuda/Dockerfile
+++ b/docker/clang-cuda/Dockerfile
@@ -81,6 +81,5 @@ COPY --from=tpl_toolchain ${GEOSX_TPL_DIR} ${GEOSX_TPL_DIR}
 RUN apt-get install -y --no-install-recommends \
     openssh-client \
     texlive \
-    graphviz
-
-RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja
+    graphviz \
+    ninja-build

--- a/docker/clang-cuda/Dockerfile
+++ b/docker/clang-cuda/Dockerfile
@@ -81,4 +81,5 @@ COPY --from=tpl_toolchain ${GEOSX_TPL_DIR} ${GEOSX_TPL_DIR}
 RUN apt-get install -y --no-install-recommends \
     openssh-client \
     texlive \
-    graphviz
+    graphviz \
+    ninja-build

--- a/docker/clang-cuda/Dockerfile
+++ b/docker/clang-cuda/Dockerfile
@@ -19,7 +19,7 @@ RUN rm /etc/apt/sources.list.d/*.list \
     python3
 
 # Installing latest CMake version available on Lassen
-ARG CMAKE_VERSION=3.17.5
+ARG CMAKE_VERSION=3.21.7
 RUN curl -s https://cmake.org/files/v${CMAKE_VERSION%.[0-9]*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar --directory=/usr/local --strip-components=1 -xzf -
 
 # Installing clang
@@ -81,7 +81,5 @@ COPY --from=tpl_toolchain ${GEOSX_TPL_DIR} ${GEOSX_TPL_DIR}
 RUN apt-get install -y --no-install-recommends \
     openssh-client \
     texlive \
-    graphviz
-
-# The ninja version provided by the current ubuntu version is too old.
-RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja
+    graphviz \
+    ninja-build

--- a/docker/gcc-cuda/Dockerfile
+++ b/docker/gcc-cuda/Dockerfile
@@ -80,7 +80,6 @@ RUN curl -fsSL https://cmake.org/files/v${CMAKE_VERSION%.[0-9]*}/cmake-${CMAKE_V
 
 # Installing dependencies
 RUN yum -y install \
-    make \
     tbb \
     blas-devel \
     lapack-devel \
@@ -107,6 +106,7 @@ ENV OMPI_FC=${FC}
 
 RUN yum install -y \
     tbb-devel \
+    make \
     bc \
     file \
     bison \
@@ -144,3 +144,5 @@ RUN yum install -y \
     texlive \
     graphviz \
     git
+
+RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja

--- a/docker/gcc-ubuntu/Dockerfile
+++ b/docker/gcc-ubuntu/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update
 # DEBIAN_FRONTEND and TZ variables fix this.
 RUN DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles \
     apt-get install -y --no-install-recommends \
-    make \
 # gfortran 8, 9 and 10 depend on libgfortran5.
     gcc-${GCC_MAJOR_VERSION} \
     g++-${GCC_MAJOR_VERSION} \
@@ -78,6 +77,7 @@ ENV OMPI_FC=$FC
 RUN apt-get install -y --no-install-recommends \
     libtbb-dev \
     gfortran-${GCC_MAJOR_VERSION} \
+    make \
     bc \
     file \
     bison \
@@ -117,4 +117,5 @@ RUN apt-get install -y --no-install-recommends \
     graphviz \
     libxml2-utils \
     git \
-    ghostscript
+    ghostscript \
+    ninja-build

--- a/scripts/config-build.py
+++ b/scripts/config-build.py
@@ -78,6 +78,11 @@ def parse_args(cli_arguments):
                         action='store_true',
                         help="create an eclipse project file.")
 
+    parser.add_argument("-n",
+                        "--ninja",
+                        action='store_true', 
+                        help="Create a ninja project.")
+
     parser.add_argument("-x",
                         "--xcode",
                         action='store_true',
@@ -177,6 +182,9 @@ def main(calling_script, args, unknown_args):
 
     if args.eclipse:
         cmake_line.append('-G"Eclipse CDT4 - Unix Makefiles"')
+
+    if args.ninja:
+        cmake_line.append('-GNinja')
 
     if args.xcode:
         cmake_line.append('-GXcode')


### PR DESCRIPTION
Build GEOSX with [ninja](https://ninja-build.org/) instead of make.
The building tool for TPLs is unchanged, but the installation of `ninja` requires this TPL update.

Related to PR https://github.com/GEOSX/GEOSX/pull/2155